### PR TITLE
Fix pd.read_csv without index column

### DIFF
--- a/project/project_1/project_1_starter.ipynb
+++ b/project/project_1/project_1_starter.ipynb
@@ -67,9 +67,9 @@
    },
    "outputs": [],
    "source": [
-    "df = pd.read_csv('../../data/project_1/eod-quotemedia.csv', parse_dates=['date'], index_col=False)\n",
+    "df = pd.read_csv('../../data/project_1/eod-quotemedia.csv', parse_dates=['date'])\n",
     "\n",
-    "close = df.reset_index().pivot(index='date', columns='ticker', values='adj_close')\n",
+    "close = df.pivot(index='date', columns='ticker', values='adj_close')\n",
     "\n",
     "print('Loaded Data')"
    ]


### PR DESCRIPTION
If `index_col=None` (default value), instead of `False` (which evaluates to zero, as it expects an int), no column is used to set the DataFrame index. Thus, it is no longer necessary to reset the index afterwards (no need of `.reset_index()`).